### PR TITLE
Fix endless loop for error case (#63)

### DIFF
--- a/lib/Service/OcrService.php
+++ b/lib/Service/OcrService.php
@@ -476,6 +476,8 @@ class OcrService {
 					$this->statusMapper->delete($status);
 					exec('rm ' . $status->getTempFile());
 				} else {
+					// Delete status before raising an exception to avoid an endless loop.
+					$this->statusMapper->delete($status);
 					throw new NotFoundException($this->l10n->t('Temp file does not exist.'));
 				}
 			}


### PR DESCRIPTION
If the temporary file created by OCR was not found, that error was
reported endlessly because the status was never reset.

Signed-off-by: Stefan Weil <sw@weilnetz.de>
