### PR TITLE
Minor typos + lift max nextcloud version to 12

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,11 +9,11 @@
     <description lang="en"><![CDATA[
 # Description
 
-Nextcloud OCR (optical character recognition) processing for images and PDF with tesseract-ocr and OCRmyPDF brings OCR capability to your Nextcloud 10.
+Nextcloud OCR (optical character recognition) processing for images and PDF with tesseract-ocr and OCRmyPDF brings OCR capability to your Nextcloud.
 The app uses tesseract-ocr, OCRmyPDF and a php internal message queueing service in order to process images (png, jpeg, tiff) and PDF (currently not all PDF-types are supported, for more information see [here](https://github.com/jbarlow83/OCRmyPDF)) asynchronously and save the output file to the same folder in nextcloud, so you are able to search in it.
 The source data won&#39;t get lost. Instead:
  - in case of a PDF a copy will be saved with an extra layer of the processed text, so that you are able to search in it.
- - in case of a image the result of the OCR processing will be saved in a .txt file next to the image (same folder).
+ - in case of an image the result of the OCR processing will be saved in a .txt file next to the image (same folder).
 
 **One big feature is the asynchronous ocr processing brought by the internal php message queueing system (Semaphore functions), which supports workers to handle tasks asynchronous from the rest of nextcloud.**
 
@@ -31,8 +31,8 @@ For further information see the homepage or the appropriate documentation.
     <description lang="de"><![CDATA[
 # Beschreibung
 
-OCR (Automatische Texterkennung) für Bilder (mit Text) und PDF Dateien mithilfe von tesseract-ocr und OCRmyPDF ermöglicht Ihnen automatische Schrifterkennung direkt in Ihrer Nextcloud 10.
-Die App nutzt Tesseract-ocr, OCRmyPDF und den internen Message Queueing Service von PHP, um so asynchron (im Hintegrund) Bilder (PNG, JPEG, TIFF) und PDFs (aktuell werden nicht alle Typen unterstützt, näheres [hier](https://github.com/jbarlow83/OCRmyPDF)) zu verarbeiten. Das Ergebnis, welches jetzt durchsuchbar, kopierbar und ähnliches ist, wird anschließend im selben Ordner gespeichert, wie die Ursprungsdatei.
+OCR (Automatische Texterkennung) für Bilder (mit Text) und PDF Dateien mithilfe von tesseract-ocr und OCRmyPDF ermöglicht Ihnen automatische Schrifterkennung direkt in Ihrer Nextcloud.
+Die App nutzt Tesseract-ocr, OCRmyPDF und den internen Message Queueing Service von PHP, um so asynchron (im Hintergrund) Bilder (PNG, JPEG, TIFF) und PDFs (aktuell werden nicht alle Typen unterstützt, näheres [hier](https://github.com/jbarlow83/OCRmyPDF)) zu verarbeiten. Das Ergebnis, welches jetzt durchsuchbar, kopierbar und ähnliches ist, wird anschließend im selben Ordner gespeichert, wie die Ursprungsdatei.
 Die Ursuprungsdatei geht dabei nicht verloren:
  - im Falle einer PDF wird eine Kopie mit einer zusätzlichen Textebene gespeichert, damit sie durchsuchbar und kopierbar wird.
  - im Falle eines Bildes wird das Resultat in einer txt-Datei gespeichert.
@@ -46,7 +46,7 @@ Für die OCR App müssen folgende Anforderungen erfüllt sein:
  - **[OCRmyPDF](https://github.com/jbarlow83/OCRmyPDF)** &gt;v2.x (getestet mit v4.1.3 (v4 empfohlen))
  - **[tesseract-ocr](https://github.com/tesseract-ocr/tesseract)** &gt;v3.02.02 mit den dazugehörigen Übersetzungs- und Sprachdateien (z. B. tesseract-ocr-deu)
 
-**Bitte beachten: Die App untersützt keine aktivierte Verschlüsselung der Dateien und wird es auch voraussichtlich nicht in der Zukunft. Außerdem muss ein aktiver OCRWorker Prozess gestartet sein (Details im Wiki).**
+**Bitte beachten: Die App unterstützt keine aktivierte Verschlüsselung der Dateien und wird es auch voraussichtlich nicht in der Zukunft. Außerdem muss ein aktiver OCRWorker Prozess gestartet sein (Details im Wiki).**
 
 Für weiter Informationen besuchen Sie die Homepage oder lesen Sie die zutreffende Dokumentation.
 ]]></description>
@@ -76,7 +76,7 @@ Für weiter Informationen besuchen Sie die Homepage oder lesen Sie die zutreffen
         <database>mysql</database>
         <database>sqlite</database>
         <owncloud min-version="9.2" max-version="9.2"/>
-        <nextcloud min-version="11" max-version="11" />
+        <nextcloud min-version="11" max-version="12" />
     </dependencies>
     <repair-steps>
         <pre-migration>


### PR DESCRIPTION
## Description
Made some minor spelling mistake corrections.
OCR is not just for nextcloud 10, so removed "10" from text.
Increased max nextcloud version number to 12, so people can test the master with nextcloud 12 slightly more easily.

## Related Issue
- https://help.nextcloud.com/t/not-compatible-with-nextcloud-12-0-0/13045
- https://github.com/janis91/ocr/issues/53

## Motivation and Context
The app can now be enabled within nextcloud 12.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
