### PR TITLE
Add missing css classes for personal settings page

### DIFF
--- a/css/ocrpersonal.css
+++ b/css/ocrpersonal.css
@@ -15,6 +15,10 @@ table.ocrsettings td.ocr-action-delete:hover {
     font-weight: bold;
     color: black;
 }
+
+.nav-icon-schrifterkennung,
+.nav-icon-karakter-tanıma,
+.nav-icon-texterkennung,
 .nav-icon-ocr {
 	background-image: url('../img/icon/ocr.svg');
 }


### PR DESCRIPTION
The icon for the OCR section is missing in the personal settings under Nextcloud 12. This only affects languages where the key "OCR" has been translated to something different than "OCR"

## Description
I added css classes for the tree cases which I found where the key "OCR" has been translated.

## Related Issue
See https://github.com/janis91/ocr/issues/91

## Motivation and Context
See: https://github.com/janis91/ocr/issues/91

## How Has This Been Tested?
Added the classes and checked if the problem is fixed

## Screenshots (if appropriate):
![grafik](https://user-images.githubusercontent.com/8255857/27011412-75dbd1bc-4ebb-11e7-9547-adb061edacdb.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
