### PR TITLE
Fix some new typos in documentation, comments and log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 #Changelog
 nextcloud-ocr (3.0.0-beta.7)
-* **Upcomming Release**: The next major release of OCR is here soon. Some tests have too pass before I will publish it. But This is kind of a Release Candidate.
+* **Upcoming Release**: The next major release of OCR is here soon. Some tests have too pass before I will publish it. But This is kind of a Release Candidate.
 * **Major Changes**: The app got completely refactored. It now is based on redis for the communication with a worker which got also completely reworked and is now basically a nodejs application. This nodejs worker gets setup inside of a docker container to have always the latest tesseract and ocrmypdf available and be much more scalable than before. Maybe already Cloud ready. The other refactoring part targeted the php code, that got a lot better now and can now be adjusted way faster and gets way more unit tested than before. This applies also for the worker. Moreover an administration page is now available to configure the redis endpoint and the installed languages inside of the ocr worker container. Another part is the logging capability. In case of an error the user now can see the corresponding message from within his personal ocr overview section.
 nextcloud-ocr (3.0.0-beta.1)
 * **Release**: Now works with NC12. From now on a new Major Release will be released with each major NC version. Older versions will then not be supported anymore (they are still working maybe, but I don't have the time to support those).

--- a/js/src/app/service/http.service.ts
+++ b/js/src/app/service/http.service.ts
@@ -57,7 +57,7 @@ export class HttpService {
 
     /**
      * Retrieve all available languages for processing files.
-     * @returns A string of languages seperated by semicolon.
+     * @returns A string of languages separated by semicolon.
      */
     public loadAvailableLanguages(): JQueryXHR {
         const options: JQueryAjaxSettings = {

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -32,7 +32,7 @@ export class Worker {
      */
     public loop() {
         this.redisClient.brpoplpush('incoming', 'working', 0).then((jobMessage: string) => {
-            this.logger.debug(`Message recieved from Redis server: ${jobMessage}`);
+            this.logger.debug(`Message received from Redis server: ${jobMessage}`);
             try {
                 this.ocrProcessingService.process(jobMessage);
             } catch (e) {


### PR DESCRIPTION
Two of them were found by codespell.

Signed-off-by: Stefan Weil <sw@weilnetz.de>