### PR TITLE
Fix overlapping elements in the selected action list header

### DIFF
--- a/js/src/app/view/view.spec.ts
+++ b/js/src/app/view/view.spec.ts
@@ -251,7 +251,7 @@ describe('For the view', () => {
 
             cut.destroySelectedFilesActionButton();
 
-            expect(documentMock.getElementById).toHaveBeenCalledWith('selectedActionsOCRId');
+            expect(documentMock.getElementById).toHaveBeenCalledWith('selectedFilesOCR');
         });
     });
 

--- a/js/src/app/view/view.ts
+++ b/js/src/app/view/view.ts
@@ -17,12 +17,11 @@ export class View {
 
     /** Template for the OCR selected file action in the top bar. */
     private readonly _templateOCRSelectedFileAction: string = `
-    <span id="selectedActionsOCRId" class="selectedActionsOCR hidden">
-        <a id="selectedFilesOCR" href="" class="ocr">
+        <a id="selectedFilesOCR" href="" class="ocr hidden">
             <span class="icon icon-ocr"></span>
             <span class="pad-for-icon">${t('ocr', 'OCR')}</span>
         </a>
-    </span>`;
+    `;
 
     /** The row of the notification for the pending state. */
     private _notificationRow: number = undefined;
@@ -88,7 +87,7 @@ export class View {
      * @param show If show or hide.
      */
     public toggleSelectedFilesActionButton(show: boolean): void {
-        const selectedActionsOCR = this.document.getElementById('selectedActionsOCRId');
+        const selectedActionsOCR = this.document.getElementById('selectedFilesOCR');
         if (show) {
             this.removeClass(selectedActionsOCR, 'hidden');
         } else {
@@ -135,7 +134,7 @@ export class View {
      * Renders the selected files action button.
      */
     public renderSelectedFilesActionButton(): void {
-        this.appendHtmlToElement(this.templateOCRSelectedFileAction, this.document.getElementById('headerName-container'));
+        this.appendHtmlToElement(this.templateOCRSelectedFileAction, this.document.getElementById('selectedActionsList'));
     }
 
     /**
@@ -150,7 +149,7 @@ export class View {
      * Destroys the selected files action button.
      */
     public destroySelectedFilesActionButton(): void {
-        this.removeElement(this.document.getElementById('selectedActionsOCRId'));
+        this.removeElement(this.document.getElementById('selectedFilesOCR'));
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Stefan Weil <sw@weilnetz.de>

## Description
This fixes the overlapping elements (which make a user selection impossible) for me.
I'm not sure whether this is the correct solution, so please review carefully.

## Related Issue
See issue #142.

## Motivation and Context
See issue #142.

## How Has This Been Tested?
Select one or more image files in Nextcloud's file view. I only tested with Nextcloud 13.
