### PR TITLE
Update worker.configuration.ts

### DIFF
--- a/worker/src/configuration/worker.configuration.ts
+++ b/worker/src/configuration/worker.configuration.ts
@@ -5,11 +5,11 @@ export class Configuration {
 
     public static readonly ENVIRONMENT_PRODUCTION = 'production';
     public static readonly REDIS_CLIENT_OPTIONS: RedisOptions = {
-        db: process.env.REDIS_DB || 0,
+        db: parseInt(process.env.REDIS_DB) || 0,
         host: process.env.REDIS_HOST || 'redis',
         keyPrefix: 'ocr:',
         password: process.env.REDIS_PASSWORD || null,
-        port: process.env.REDIS_PORT || 6379,
+        port: parseInt(process.env.REDIS_PORT) || 6379,
         reconnectOnError: function (err) {
             if (err.message.slice(0, 'READONLY'.length) === 'READONLY') {
                 return true;


### PR DESCRIPTION
fix Typescript Type 'number' is not assignable │ to type 'string'

docker build --build-arg LANGUAGES="tesseract-ocr-deu" -t {myname}/ocr .  works again.
